### PR TITLE
path to languages.php

### DIFF
--- a/PolylangHelperFunctions.php
+++ b/PolylangHelperFunctions.php
@@ -32,7 +32,7 @@ function pll_installed_language_list() {
  */
 function pll_get_default_language_information($language_code) {
 	global $polylang;
-	require(PLL_ADMIN_INC.'/languages.php');
+	require(PLL_SETTINGS_INC.'/languages.php');
 	foreach ($languages as $language) {
 		if ($language[0] == $language_code || $language[1] == $language_code) {
 			$rtl = (count($language) > 3) && ($language[3] == 'rtl');


### PR DESCRIPTION
Looks like the path to `languages.php` has changed in a previous release
of polylang
